### PR TITLE
fix: verify Cyberint IoC TLS certificates by default

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2025 Splunk Inc.
+   Copyright 2025-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: Cyberint IoC
-Copyright (c) Check Point Cyberint, 2025
+Copyright (c) Check Point Cyberint, 2025-2026

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This table lists the configuration variables required to operate Cyberint IoC. T
 
 VARIABLE | REQUIRED | TYPE | DESCRIPTION
 -------- | -------- | ---- | -----------
+**verify_server_cert** | optional | boolean | Verify the Cyberint API server certificate |
 **base_url** | required | string | Base URL of the Cyberint API |
 **access_token** | required | password | API Access Token for authentication |
 **customer_name** | required | string | The name of the company |
@@ -153,7 +154,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2025 Splunk Inc.
+# Copyright (c) 2025-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cyberintioc.json
+++ b/cyberintioc.json
@@ -10,7 +10,7 @@
     "python_version": "3.9, 3.13",
     "product_version_regex": ".*",
     "publisher": "Check Point Cyberint",
-    "license": "Copyright (c) Check Point Cyberint, 2025",
+    "license": "Copyright (c) Check Point Cyberint, 2025-2026",
     "app_version": "1.0.2",
     "utctime_updated": "2025-10-20T18:21:26.050290Z",
     "package_name": "phantom_cyberintioc",

--- a/cyberintioc.json
+++ b/cyberintioc.json
@@ -18,6 +18,14 @@
     "min_phantom_version": "6.4.0",
     "app_wizard_version": "1.0.0",
     "configuration": {
+        "verify_server_cert": {
+            "description": "Verify the Cyberint API server certificate",
+            "data_type": "boolean",
+            "required": false,
+            "default": true,
+            "order": 3,
+            "name": "Verify Server Certificate"
+        },
         "base_url": {
             "description": "Base URL of the Cyberint API",
             "data_type": "string",

--- a/cyberintioc.json
+++ b/cyberintioc.json
@@ -7,7 +7,7 @@
     "logo": "logo_cyberintioc.svg",
     "logo_dark": "logo_cyberintioc_dark.svg",
     "product_name": "Cyberint IoC",
-    "python_version": "3",
+    "python_version": "3.9, 3.13",
     "product_version_regex": ".*",
     "publisher": "Check Point Cyberint",
     "license": "Copyright (c) Check Point Cyberint, 2025",

--- a/cyberintioc_connector.py
+++ b/cyberintioc_connector.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Splunk Inc.
+# Copyright (c) 2025-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cyberintioc_connector.py
+++ b/cyberintioc_connector.py
@@ -127,7 +127,7 @@ class CyberintIocConnector(BaseConnector):
 
         url = self._base_url + endpoint
         try:
-            r = request_func(url, verify=config.get("verify_server_cert", False), **kwargs)
+            r = request_func(url, verify=config.get("verify_server_cert", True), **kwargs)
         except Exception as e:
             return RetVal(
                 action_result.set_status(phantom.APP_ERROR, f"Error Connecting to server. Details: {e}"),

--- a/cyberintioc_consts.py
+++ b/cyberintioc_consts.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Splunk Inc.
+# Copyright (c) 2025-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cyberintioc_view.py
+++ b/cyberintioc_view.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Splunk Inc.
+# Copyright (c) 2025-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/enrich_domain_view.html
+++ b/enrich_domain_view.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2025 Splunk Inc.
+ Copyright (c) 2025-2026 Splunk Inc.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/enrich_ipv4_view.html
+++ b/enrich_ipv4_view.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2025 Splunk Inc.
+ Copyright (c) 2025-2026 Splunk Inc.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/enrich_sha256_view.html
+++ b/enrich_sha256_view.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2025 Splunk Inc.
+ Copyright (c) 2025-2026 Splunk Inc.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/enrich_url_view.html
+++ b/enrich_url_view.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2025 Splunk Inc.
+ Copyright (c) 2025-2026 Splunk Inc.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/ioc_view.html
+++ b/ioc_view.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2025 Splunk Inc.
+ Copyright (c) 2025-2026 Splunk Inc.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* - Verify Cyberint API server certificates by default.
+* Verify Cyberint API server certificates by default.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-- Verify Cyberint API server certificates by default.
+* - Verify Cyberint API server certificates by default.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+- Verify Cyberint API server certificates by default.


### PR DESCRIPTION
## Summary

- add a server-certificate verification asset setting that defaults to enabled
- default runtime verification to enabled for existing assets without the new setting
- leave SOAR-local REST access unchanged
- refresh generated connector metadata and dependency manifests

## Tracking

- PAPP-38152
- Parent epic: ESPM-5228
- PSAAS-30978

## Validation

- local compile: passed
- local pre-commit and static tests: passed
- hosted pre-commit and compile: pending

Created by Codex with AI assistance.

## Tracking

- PAPP: PAPP-38152
- PSAAS: PSAAS-30978
- Written by Codex.