### PR TITLE
Require strict Cyberint IoC certificate checks

### DIFF
--- a/cyberintioc_connector.py
+++ b/cyberintioc_connector.py
@@ -127,7 +127,7 @@ class CyberintIocConnector(BaseConnector):
 
         url = self._base_url + endpoint
         try:
-            r = request_func(url, verify=config.get("verify_server_cert", True), **kwargs)
+            r = request_func(url, verify=config.get("verify_server_cert") is not False, **kwargs)
         except Exception as e:
             return RetVal(
                 action_result.set_status(phantom.APP_ERROR, f"Error Connecting to server. Details: {e}"),
@@ -194,7 +194,7 @@ class CyberintIocConnector(BaseConnector):
             sdi = f"cyberint_ioc_feed_{today}"
             url = f"{self.get_phantom_base_url()}/rest/container?_filter_source_data_identifier='{sdi}'"
             try:
-                r = self._get_requests_session().get(url, verify=False)
+                r = self._get_requests_session().get(url, verify=True)
                 r.raise_for_status()
                 data = r.json()
                 if data.get("count", 0) > 0:

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,5 @@
 **Unreleased**
 
 * Removed obsolete CI workflow templates.
+* Missing or null certificate-verification settings now retain strict verification for Cyberint API requests.
+* SOAR container lookups now require strict platform TLS verification.


### PR DESCRIPTION
Written by Codex.

Jira: [PAPP-38152](https://splunk.atlassian.net/browse/PAPP-38152) | [PSAAS-30978](https://splunk.atlassian.net/browse/PSAAS-30978) | [VULN-93703](https://splunk.atlassian.net/browse/VULN-93703)

Changes:
- Preserve certificate verification when the Cyberint API setting is missing or null.
- Require strict TLS verification for the SOAR-internal container lookup.
- Document each request-funnel change on its own release-note line.

Quality gate:
- Full local pre-commit suite passed.
- Python compilation passed.
- Hosted pre-commit and compile checks are pending; this PR remains a draft until they pass.

Please preserve the individual commits when merging; do not squash.